### PR TITLE
Replaced BM scraping with BM api

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,3 @@
+bm_api_key = "INSERT YOUR BM API KEY HERE"
+
+#get your battlemetrics api key here: https://www.battlemetrics.com/developers


### PR DESCRIPTION
The script now collects the names of all players, that have been on the server the last 30 days, instead of only online players.
If you don't want to input an api key, you can remove the comment in line 35 and replace it with a comment in line 34.